### PR TITLE
Update detectLocale method to skip word with less than 2 characters (+ sync with origin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ const (
     LocaleCsCZ = "cs_CZ" // Czech (Czech Republic)
     LocaleSlSI = "sl_SI" // Slovenian (Slovenia)
     LocaleLtLT = "lt_LT" // Lithuanian (Lithuania)
-    LocaleThTH = "th_TH" // Thai (Thialand)
+    LocaleThTH = "th_TH" // Thai (Thailand)
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ const (
     LocaleSlSI = "sl_SI" // Slovenian (Slovenia)
     LocaleLtLT = "lt_LT" // Lithuanian (Lithuania)
     LocaleThTH = "th_TH" // Thai (Thailand)
+    LocaleUzUZ = "uz_UZ" // Uzbek (Uzbekistan)
+    LocaleKkKZ = "kk_KZ" // Kazakh (Kazakhstan)
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ const (
     LocaleCsCZ = "cs_CZ" // Czech (Czech Republic)
     LocaleSlSI = "sl_SI" // Slovenian (Slovenia)
     LocaleLtLT = "lt_LT" // Lithuanian (Lithuania)
+    LocaleThTH = "th_TH" // Thai (Thialand)
 )
 ```
 

--- a/automation.go
+++ b/automation.go
@@ -322,6 +322,10 @@ func (ld *LocaleDetector) detectLocale(value string) Locale {
 	for _, v := range wordsRx.FindAllStringSubmatchIndex(value, -1) {
 		word := strings.ToLower(value[v[0]:v[1]])
 
+		if len(word) <= 1 {
+			continue
+		}
+
 		if localesSet, ok := ld.localeMap[word]; ok {
 			localesSet.Each(func(loc Locale) bool {
 				if _, ok := localesMap[loc]; !ok {

--- a/automation_test.go
+++ b/automation_test.go
@@ -36,17 +36,16 @@ var (
 				LocaleEnUS,
 			},
 		},
-		// Failing for the et-EE because the 'T' from the date is matched by the Tuesday (T) of Estonian
-		// layoutData{
-		// 	layout: "2006-01-02T15:04:05-07:00",
-		// 	matches: []string{
-		// 		"2019-12-22T00:35:44+02:00",
-		// 		"2016-02-02T00:00:00+03:00",
-		// 		"2016-01-26T00:10:21-03:00",
-		// 		"2016-01-26T22:15:30+03:00",
-		// 	},
-		// 	locales: makeSingleLocalesArray(LocaleEnUS, 4),
-		// },
+		layoutData{
+			layout: "2006-01-02T15:04:05-07:00",
+			matches: []string{
+				"2019-12-22T00:35:44+02:00",
+				"2016-02-02T00:00:00+03:00",
+				"2016-01-26T00:10:21-03:00",
+				"2016-01-26T22:15:30+03:00",
+			},
+			locales: makeSingleLocalesArray(LocaleEnUS, 4),
+		},
 		layoutData{
 			layout: "Пон, 2 Янв 2006 15:4:5 -0700",
 		},

--- a/default_formats.go
+++ b/default_formats.go
@@ -270,6 +270,13 @@ const (
 	DefaultFormatUzUZShort    = "02.01.2006"
 	DefaultFormatUzUZDateTime = "02.01.2006 15:04"
 	DefaultFormatUzUZTime     = "15:04"
+
+	DefaultFormatKkKZFull     = "Monday, 2 January 2006 ж." // Kazakh (Kazakhstan)
+	DefaultFormatKkKZLong     = "2 January 2006 ж."
+	DefaultFormatKkKZMedium   = "02 Jan 2006 ж."
+	DefaultFormatKkKZShort    = "02.01.06"
+	DefaultFormatKkKZDateTime = "02.01.06, 15:04"
+	DefaultFormatKkKZTime     = "15:04"
 )
 
 // FullFormatsByLocale maps locales to the'full' date formats for all
@@ -313,6 +320,7 @@ var FullFormatsByLocale = map[Locale]string{
 	LocaleLtLT: DefaultFormatLtLTFull,
 	LocaleThTH: DefaultFormatThTHFull,
 	LocaleUzUZ: DefaultFormatUzUZFull,
+	LocaleKkKZ: DefaultFormatKkKZFull,
 }
 
 // LongFormatsByLocale maps locales to the 'long' date formats for all
@@ -356,6 +364,7 @@ var LongFormatsByLocale = map[Locale]string{
 	LocaleLtLT: DefaultFormatLtLTLong,
 	LocaleThTH: DefaultFormatThTHLong,
 	LocaleUzUZ: DefaultFormatUzUZLong,
+	LocaleKkKZ: DefaultFormatKkKZLong,
 }
 
 // MediumFormatsByLocale maps locales to the 'medium' date formats for all
@@ -399,6 +408,7 @@ var MediumFormatsByLocale = map[Locale]string{
 	LocaleLtLT: DefaultFormatLtLTMedium,
 	LocaleThTH: DefaultFormatThTHMedium,
 	LocaleUzUZ: DefaultFormatUzUZMedium,
+	LocaleKkKZ: DefaultFormatKkKZMedium,
 }
 
 // ShortFormatsByLocale maps locales to the 'short' date formats for all
@@ -441,6 +451,7 @@ var ShortFormatsByLocale = map[Locale]string{
 	LocaleUkUA: DefaultFormatUkUAShort,
 	LocaleLtLT: DefaultFormatLtLTShort,
 	LocaleUzUZ: DefaultFormatUzUZShort,
+	LocaleKkKZ: DefaultFormatKkKZShort,
 }
 
 // DateTimeFormatsByLocale maps locales to the 'DateTime' date formats for
@@ -483,6 +494,7 @@ var DateTimeFormatsByLocale = map[Locale]string{
 	LocaleUkUA: DefaultFormatUkUADateTime,
 	LocaleLtLT: DefaultFormatLtLTDateTime,
 	LocaleUzUZ: DefaultFormatUzUZDateTime,
+	LocaleKkKZ: DefaultFormatKkKZDateTime,
 }
 
 // TimeFormatsByLocale maps locales to the 'Time' date formats for
@@ -525,4 +537,5 @@ var TimeFormatsByLocale = map[Locale]string{
 	LocaleUkUA: DefaultFormatUkUATime,
 	LocaleLtLT: DefaultFormatLtLTTime,
 	LocaleUzUZ: DefaultFormatUzUZTime,
+	LocaleKkKZ: DefaultFormatKkKZTime,
 }

--- a/default_formats.go
+++ b/default_formats.go
@@ -10,216 +10,252 @@ const (
 	DefaultFormatEnUSMedium   = "Jan 02, 2006"
 	DefaultFormatEnUSShort    = "1/2/06"
 	DefaultFormatEnUSDateTime = "1/2/06 3:04 PM"
+	DefaultFormatEnUSTime     = "3:04 PM"
 
 	DefaultFormatEnGBFull     = "Monday, 2 January 2006" // English (United Kingdom)
 	DefaultFormatEnGBLong     = "2 January 2006"
 	DefaultFormatEnGBMedium   = "02 Jan 2006"
 	DefaultFormatEnGBShort    = "02/01/2006"
 	DefaultFormatEnGBDateTime = "02/01/2006 15:04"
+	DefaultFormatEnGBTime     = "15:04"
 
 	DefaultFormatDaDKFull     = "Monday den 2. January 2006" // Danish (Denmark)
 	DefaultFormatDaDKLong     = "2. Jan 2006"
 	DefaultFormatDaDKMedium   = "02/01/2006"
 	DefaultFormatDaDKShort    = "02/01/06"
 	DefaultFormatDaDKDateTime = "02/01/2006 15.04"
+	DefaultFormatDaDKTime     = "15.04"
 
 	DefaultFormatNlBEFull     = "Monday 2 January 2006" // Dutch (Belgium)
 	DefaultFormatNlBELong     = "2 January 2006"
 	DefaultFormatNlBEMedium   = "02-Jan-2006"
 	DefaultFormatNlBEShort    = "2/01/06"
 	DefaultFormatNlBEDateTime = "2/01/06 15:04"
+	DefaultFormatNlBETime     = "15:04"
 
 	DefaultFormatNlNLFull     = "Monday 2 January 2006" // Dutch (Netherlands)
 	DefaultFormatNlNLLong     = "2 January 2006"
 	DefaultFormatNlNLMedium   = "02 Jan 2006"
 	DefaultFormatNlNLShort    = "02-01-06"
 	DefaultFormatNlNLDateTime = "02-01-06 15:04"
+	DefaultFormatNlNLTime     = "15:04"
 
 	DefaultFormatFiFIFull     = "Monday 2. January 2006" // Finnish (Finland)
 	DefaultFormatFiFILong     = "2. January 2006"
 	DefaultFormatFiFIMedium   = "02.1.2006"
 	DefaultFormatFiFIShort    = "02.1.2006"
 	DefaultFormatFiFIDateTime = "02.1.2006 15.04"
+	DefaultFormatFiFITime     = "15.04"
 
 	DefaultFormatFrFRFull     = "Monday 2 January 2006" // French (France)
 	DefaultFormatFrFRLong     = "2 January 2006"
 	DefaultFormatFrFRMedium   = "02 Jan 2006"
 	DefaultFormatFrFRShort    = "02/01/2006"
 	DefaultFormatFrFRDateTime = "02/01/2006 15:04"
+	DefaultFormatFrFRTime     = "15:04"
 
 	DefaultFormatFrCAFull     = "Monday 2 January 2006" // French (Canada)
 	DefaultFormatFrCALong     = "2 January 2006"
 	DefaultFormatFrCAMedium   = "2006-01-02"
 	DefaultFormatFrCAShort    = "06-01-02"
 	DefaultFormatFrCADateTime = "06-01-02 15:04"
+	DefaultFormatFrCATime     = "15:04"
 
 	DefaultFormatFrGPFull     = "Monday 2 January 2006" // French (Guadeloupe)
 	DefaultFormatFrGPLong     = "2 January 2006"
 	DefaultFormatFrGPMedium   = "2006-01-02"
 	DefaultFormatFrGPShort    = "06-01-02"
 	DefaultFormatFrGPDateTime = "06-01-02 15:04"
+	DefaultFormatFrGPTime     = "15:04"
 
 	DefaultFormatFrLUFull     = "Monday 2 January 2006" // French (Luxembourg)
 	DefaultFormatFrLULong     = "2 January 2006"
 	DefaultFormatFrLUMedium   = "2006-01-02"
 	DefaultFormatFrLUShort    = "06-01-02"
 	DefaultFormatFrLUDateTime = "06-01-02 15:04"
+	DefaultFormatFrLUTime     = "15:04"
 
 	DefaultFormatFrMQFull     = "Monday 2 January 2006" // French (Martinique)
 	DefaultFormatFrMQLong     = "2 January 2006"
 	DefaultFormatFrMQMedium   = "2006-01-02"
 	DefaultFormatFrMQShort    = "06-01-02"
 	DefaultFormatFrMQDateTime = "06-01-02 15:04"
+	DefaultFormatFrMQTime     = "15:04"
 
 	DefaultFormatFrGFFull     = "Monday 2 January 2006" // French (French Guiana)
 	DefaultFormatFrGFLong     = "2 January 2006"
 	DefaultFormatFrGFMedium   = "2006-01-02"
 	DefaultFormatFrGFShort    = "06-01-02"
 	DefaultFormatFrGFDateTime = "06-01-02 15:04"
+	DefaultFormatFrGFTime     = "15:04"
 
 	DefaultFormatFrREFull     = "Monday 2 January 2006" // French (Reunion)
 	DefaultFormatFrRELong     = "2 January 2006"
 	DefaultFormatFrREMedium   = "2006-01-02"
 	DefaultFormatFrREShort    = "06-01-02"
 	DefaultFormatFrREDateTime = "06-01-02 15:04"
+	DefaultFormatFrRETime     = "15:04"
 
 	DefaultFormatDeDEFull     = "Monday, 2. January 2006" // German (Germany)
 	DefaultFormatDeDELong     = "2. January 2006"
 	DefaultFormatDeDEMedium   = "02.01.2006"
 	DefaultFormatDeDEShort    = "02.01.06"
 	DefaultFormatDeDEDateTime = "02.01.06 15:04"
+	DefaultFormatDeDETime     = "15:04"
 
 	DefaultFormatHuHUFull     = "2006. January 2., Monday" // Hungarian (Hungary)
 	DefaultFormatHuHULong     = "2006. January 2."
 	DefaultFormatHuHUMedium   = "2006.01.02."
 	DefaultFormatHuHUShort    = "2006.01.02."
 	DefaultFormatHuHUDateTime = "2006.01.02. 15:04"
+	DefaultFormatHuHUTime     = "15:04"
 
 	DefaultFormatItITFull     = "Monday 2 January 2006" // Italian (Italy)
 	DefaultFormatItITLong     = "2 January 2006"
 	DefaultFormatItITMedium   = "02/Jan/2006"
 	DefaultFormatItITShort    = "02/01/06"
 	DefaultFormatItITDateTime = "02/01/06 15:04"
+	DefaultFormatItITTime     = "15:04"
 
 	DefaultFormatNnNOFull     = "Monday 2. January 2006" // Norwegian Nynorsk (Norway)
 	DefaultFormatNnNOLong     = "2. January 2006"
 	DefaultFormatNnNOMedium   = "02. Jan 2006"
 	DefaultFormatNnNOShort    = "02.01.06"
 	DefaultFormatNnNODateTime = "02.01.06 15:04"
+	DefaultFormatNnNOTime     = "15:04"
 
 	DefaultFormatNbNOFull     = "Monday 2. January 2006" // Norwegian Bokmål (Norway)
 	DefaultFormatNbNOLong     = "2. January 2006"
 	DefaultFormatNbNOMedium   = "02. Jan 2006"
 	DefaultFormatNbNOShort    = "02.01.06"
 	DefaultFormatNbNODateTime = "15:04 02.01.06"
+	DefaultFormatNbNOTime     = "15:04"
 
 	DefaultFormatPtPTFull     = "Monday, 2 de January de 2006" // Portuguese (Portugal)
 	DefaultFormatPtPTLong     = "2 de January de 2006"
 	DefaultFormatPtPTMedium   = "02/01/2006"
 	DefaultFormatPtPTShort    = "02/01/06"
 	DefaultFormatPtPTDateTime = "02/01/06, 15:04"
+	DefaultFormatPtPTTime     = "15:04"
 
 	DefaultFormatPtBRFull     = "Monday, 2 de January de 2006" // Portuguese (Brazil)
 	DefaultFormatPtBRLong     = "02 de January de 2006"
 	DefaultFormatPtBRMedium   = "02/01/2006"
 	DefaultFormatPtBRShort    = "02/01/06"
 	DefaultFormatPtBRDateTime = "02/01/06, 15:04"
+	DefaultFormatPtBRTime     = "15:04"
 
 	DefaultFormatRoROFull     = "Monday, 02 January 2006" // Romanian (Romania)
 	DefaultFormatRoROLong     = "02 January 2006"
 	DefaultFormatRoROMedium   = "02.01.2006"
 	DefaultFormatRoROShort    = "02.01.2006"
 	DefaultFormatRoRODateTime = "02.01.06, 15:04"
+	DefaultFormatRoROTime     = "15:04"
 
 	DefaultFormatRuRUFull     = "Monday, 2 January 2006 г." // Russian (Russia)
 	DefaultFormatRuRULong     = "2 January 2006 г."
 	DefaultFormatRuRUMedium   = "02 Jan 2006 г."
 	DefaultFormatRuRUShort    = "02.01.06"
 	DefaultFormatRuRUDateTime = "02.01.06, 15:04"
+	DefaultFormatRuRUTime     = "15:04"
 
 	DefaultFormatEsESFull     = "Monday, 2 de January de 2006" // Spanish (Spain)
 	DefaultFormatEsESLong     = "2 de January de 2006"
 	DefaultFormatEsESMedium   = "02/01/2006"
 	DefaultFormatEsESShort    = "02/01/06"
 	DefaultFormatEsESDateTime = "02/01/06 15:04"
+	DefaultFormatEsESTime     = "15:04"
 
 	DefaultFormatCaESFull     = "Monday, 2 de January de 2006" // Spanish (Spain)
 	DefaultFormatCaESLong     = "2 de January de 2006"
 	DefaultFormatCaESMedium   = "02/01/2006"
 	DefaultFormatCaESShort    = "02/01/06"
 	DefaultFormatCaESDateTime = "02/01/06 15:04"
+	DefaultFormatCaESTime     = "15:04"
 
 	DefaultFormatSvSEFull     = "Mondayen den 2:e January 2006" // Swedish (Sweden)
 	DefaultFormatSvSELong     = "2 January 2006"
 	DefaultFormatSvSEMedium   = "2 Jan 2006"
 	DefaultFormatSvSEShort    = "2006-01-02"
 	DefaultFormatSvSEDateTime = "2006-01-02 15:04"
+	DefaultFormatSvSETime     = "15:04"
 
 	DefaultFormatTrTRFull     = "2 January 2006 Monday" // Turkish (Turkey)
 	DefaultFormatTrTRLong     = "2 January 2006"
 	DefaultFormatTrTRMedium   = "2 Jan 2006"
 	DefaultFormatTrTRShort    = "2.01.2006"
 	DefaultFormatTrTRDateTime = "2.01.2006 15:04"
+	DefaultFormatTrTRTime     = "15:04"
 
 	DefaultFormatUkUAFull     = "Monday, 2 January 2006 р." // Ukrainian (Ukraine)
 	DefaultFormatUkUALong     = "2 January 2006 р."
 	DefaultFormatUkUAMedium   = "02 Jan 2006 р."
 	DefaultFormatUkUAShort    = "02.01.06"
 	DefaultFormatUkUADateTime = "02.01.06, 15:04"
+	DefaultFormatUkUATime     = "15:04"
 
 	DefaultFormatBgBGFull     = "Monday, 2 January 2006" // Bulgarian (Bulgaria)
 	DefaultFormatBgBGLong     = "2 January 2006"
 	DefaultFormatBgBGMedium   = "2 Jan 2006"
 	DefaultFormatBgBGShort    = "2.01.2006"
 	DefaultFormatBgBGDateTime = "2.01.2006 15:04"
+	DefaultFormatBgBGTime     = "15:04"
 
 	DefaultFormatZhCNFull     = "2006年1月2日 Monday" // Chinese (Mainland)
 	DefaultFormatZhCNLong     = "2006年1月2日"
 	DefaultFormatZhCNMedium   = "2006-01-02"
 	DefaultFormatZhCNShort    = "2006/1/2"
 	DefaultFormatZhCNDateTime = "2006-01-02 15:04"
+	DefaultFormatZhCNTime     = "15:04"
 
 	DefaultFormatZhTWFull     = "2006年1月2日 Monday" // Chinese (Taiwan)
 	DefaultFormatZhTWLong     = "2006年1月2日"
 	DefaultFormatZhTWMedium   = "2006-01-02"
 	DefaultFormatZhTWShort    = "2006/1/2"
 	DefaultFormatZhTWDateTime = "2006-01-02 15:04"
+	DefaultFormatZhTWTime     = "15:04"
 
 	DefaultFormatZhHKFull     = "2006年1月2日 Monday" // Chinese (Hong Kong)
 	DefaultFormatZhHKLong     = "2006年1月2日"
 	DefaultFormatZhHKMedium   = "2006-01-02"
 	DefaultFormatZhHKShort    = "2006/1/2"
 	DefaultFormatZhHKDateTime = "2006-01-02 15:04"
+	DefaultFormatZhHKTime     = "15:04"
 
 	DefaultFormatKoKRFull     = "2006년1월2일 월요일" // Korean (Korea)
 	DefaultFormatKoKRLong     = "2006년1월2일"
 	DefaultFormatKoKRMedium   = "2006-01-02"
 	DefaultFormatKoKRShort    = "2006/1/2"
 	DefaultFormatKoKRDateTime = "2006-01-02 15:04"
+	DefaultFormatKoKRTime     = "15:04"
 
 	DefaultFormatJaJPFull     = "2006年1月2日 Monday" // Japanese (Japan)
 	DefaultFormatJaJPLong     = "2006年1月2日"
 	DefaultFormatJaJPMedium   = "2006/01/02"
 	DefaultFormatJaJPShort    = "2006/1/2"
 	DefaultFormatJaJPDateTime = "2006/01/02 15:04"
+	DefaultFormatJaJPTime     = "15:04"
 
 	DefaultFormatElGRFull     = "Monday, 2 January 2006" // Greek (Greece)
 	DefaultFormatElGRLong     = "2 January 2006"
 	DefaultFormatElGRMedium   = "2 Jan 2006"
 	DefaultFormatElGRShort    = "02/01/06"
 	DefaultFormatElGRDateTime = "02/01/06 15:04"
+	DefaultFormatElGRTime     = "15:04"
 
 	DefaultFormatCsCZFull     = "Monday, 2. January 2006" // Czech (Czech Republic)
 	DefaultFormatCsCZLong     = "2. January 2006"
 	DefaultFormatCsCZMedium   = "02 Jan 2006"
 	DefaultFormatCsCZShort    = "02/01/2006"
 	DefaultFormatCsCZDateTime = "02/01/2006 15:04"
+	DefaultFormatCsCZTime     = "15:04"
 
 	DefaultFormatLtLTFull     = "2006 m. January 2 d., Monday" // Lithuanian (Lithuania)
 	DefaultFormatLtLTLong     = "2006 January 2 d."
 	DefaultFormatLtLTMedium   = "2006 Jan 2"
 	DefaultFormatLtLTShort    = "2006-01-02"
 	DefaultFormatLtLTDateTime = "2006-01-02, 15:04"
+	DefaultFormatLtLTTime     = "15:04"
 )
 
 // FullFormatsByLocale maps locales to the'full' date formats for all
@@ -259,7 +295,7 @@ var FullFormatsByLocale = map[Locale]string{
 	LocaleJaJP: DefaultFormatJaJPFull,
 	LocaleElGR: DefaultFormatElGRFull,
 	LocaleCsCZ: DefaultFormatCsCZFull,
-	LocaleUkUA: DefaultFormatUkUAFull,	
+	LocaleUkUA: DefaultFormatUkUAFull,
 	LocaleLtLT: DefaultFormatLtLTFull,
 }
 
@@ -425,4 +461,45 @@ var DateTimeFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZDateTime,
 	LocaleUkUA: DefaultFormatUkUADateTime,
 	LocaleLtLT: DefaultFormatLtLTDateTime,
+}
+
+// TimeFormatsByLocale maps locales to the 'Time' date formats for
+// all supported locales.
+var TimeFormatsByLocale = map[Locale]string{
+	LocaleEnUS: DefaultFormatEnUSTime,
+	LocaleEnGB: DefaultFormatEnGBTime,
+	LocaleDaDK: DefaultFormatDaDKTime,
+	LocaleNlBE: DefaultFormatNlBETime,
+	LocaleNlNL: DefaultFormatNlNLTime,
+	LocaleFiFI: DefaultFormatFiFITime,
+	LocaleFrFR: DefaultFormatFrFRTime,
+	LocaleFrCA: DefaultFormatFrCATime,
+	LocaleFrGP: DefaultFormatFrGPTime,
+	LocaleFrLU: DefaultFormatFrLUTime,
+	LocaleFrMQ: DefaultFormatFrMQTime,
+	LocaleFrGF: DefaultFormatFrGFTime,
+	LocaleFrRE: DefaultFormatFrRETime,
+	LocaleDeDE: DefaultFormatDeDETime,
+	LocaleHuHU: DefaultFormatHuHUTime,
+	LocaleItIT: DefaultFormatItITTime,
+	LocaleNnNO: DefaultFormatNnNOTime,
+	LocaleNbNO: DefaultFormatNbNOTime,
+	LocalePtPT: DefaultFormatPtPTTime,
+	LocalePtBR: DefaultFormatPtBRTime,
+	LocaleRoRO: DefaultFormatRoROTime,
+	LocaleRuRU: DefaultFormatRuRUTime,
+	LocaleEsES: DefaultFormatEsESTime,
+	LocaleCaES: DefaultFormatCaESTime,
+	LocaleSvSE: DefaultFormatSvSETime,
+	LocaleTrTR: DefaultFormatTrTRTime,
+	LocaleBgBG: DefaultFormatBgBGTime,
+	LocaleZhCN: DefaultFormatZhCNTime,
+	LocaleZhTW: DefaultFormatZhTWTime,
+	LocaleZhHK: DefaultFormatZhHKTime,
+	LocaleKoKR: DefaultFormatKoKRTime,
+	LocaleJaJP: DefaultFormatJaJPTime,
+	LocaleElGR: DefaultFormatElGRTime,
+	LocaleCsCZ: DefaultFormatCsCZTime,
+	LocaleUkUA: DefaultFormatUkUATime,
+	LocaleLtLT: DefaultFormatLtLTTime,
 }

--- a/default_formats.go
+++ b/default_formats.go
@@ -256,6 +256,13 @@ const (
 	DefaultFormatLtLTShort    = "2006-01-02"
 	DefaultFormatLtLTDateTime = "2006-01-02, 15:04"
 	DefaultFormatLtLTTime     = "15:04"
+
+	DefaultFormatThTHFull     = "Monday ที่ 2 January 2006" // Thai (Thailand)
+	DefaultFormatThTHLong     = "วันที่ 2 January 2006"
+	DefaultFormatThTHMedium   = "2 Jan 2006"
+	DefaultFormatThTHShort    = "02/01/2006"
+	DefaultFormatThTHDateTime = "02/01/2006 15:04"
+	DefaultFormatThTHTime     = "15:04"
 )
 
 // FullFormatsByLocale maps locales to the'full' date formats for all
@@ -297,6 +304,7 @@ var FullFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZFull,
 	LocaleUkUA: DefaultFormatUkUAFull,
 	LocaleLtLT: DefaultFormatLtLTFull,
+	LocaleThTH: DefaultFormatThTHFull,
 }
 
 // LongFormatsByLocale maps locales to the 'long' date formats for all
@@ -338,6 +346,7 @@ var LongFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZLong,
 	LocaleUkUA: DefaultFormatUkUALong,
 	LocaleLtLT: DefaultFormatLtLTLong,
+	LocaleThTH: DefaultFormatThTHLong,
 }
 
 // MediumFormatsByLocale maps locales to the 'medium' date formats for all
@@ -379,6 +388,7 @@ var MediumFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZMedium,
 	LocaleUkUA: DefaultFormatUkUAMedium,
 	LocaleLtLT: DefaultFormatLtLTMedium,
+	LocaleThTH: DefaultFormatThTHMedium,
 }
 
 // ShortFormatsByLocale maps locales to the 'short' date formats for all
@@ -420,6 +430,7 @@ var ShortFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZShort,
 	LocaleUkUA: DefaultFormatUkUAShort,
 	LocaleLtLT: DefaultFormatLtLTShort,
+	LocaleThTH: DefaultFormatThTHShort,
 }
 
 // DateTimeFormatsByLocale maps locales to the 'DateTime' date formats for
@@ -461,6 +472,7 @@ var DateTimeFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZDateTime,
 	LocaleUkUA: DefaultFormatUkUADateTime,
 	LocaleLtLT: DefaultFormatLtLTDateTime,
+	LocaleThTH: DefaultFormatThTHDateTime,
 }
 
 // TimeFormatsByLocale maps locales to the 'Time' date formats for
@@ -502,4 +514,5 @@ var TimeFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZTime,
 	LocaleUkUA: DefaultFormatUkUATime,
 	LocaleLtLT: DefaultFormatLtLTTime,
+	LocaleThTH: DefaultFormatThTHTime,
 }

--- a/default_formats.go
+++ b/default_formats.go
@@ -263,6 +263,13 @@ const (
 	DefaultFormatThTHShort    = "02/01/2006"
 	DefaultFormatThTHDateTime = "02/01/2006 15:04"
 	DefaultFormatThTHTime     = "15:04"
+
+	DefaultFormatUzUZFull     = "Monday, 02 January 2006" // Uzbek (Uzbekistan)
+	DefaultFormatUzUZLong     = "2 January 2006"
+	DefaultFormatUzUZMedium   = "2 Jan 2006"
+	DefaultFormatUzUZShort    = "02.01.2006"
+	DefaultFormatUzUZDateTime = "02.01.2006 15:04"
+	DefaultFormatUzUZTime     = "15:04"
 )
 
 // FullFormatsByLocale maps locales to the'full' date formats for all
@@ -305,6 +312,7 @@ var FullFormatsByLocale = map[Locale]string{
 	LocaleUkUA: DefaultFormatUkUAFull,
 	LocaleLtLT: DefaultFormatLtLTFull,
 	LocaleThTH: DefaultFormatThTHFull,
+	LocaleUzUZ: DefaultFormatUzUZFull,
 }
 
 // LongFormatsByLocale maps locales to the 'long' date formats for all
@@ -347,6 +355,7 @@ var LongFormatsByLocale = map[Locale]string{
 	LocaleUkUA: DefaultFormatUkUALong,
 	LocaleLtLT: DefaultFormatLtLTLong,
 	LocaleThTH: DefaultFormatThTHLong,
+	LocaleUzUZ: DefaultFormatUzUZLong,
 }
 
 // MediumFormatsByLocale maps locales to the 'medium' date formats for all
@@ -389,6 +398,7 @@ var MediumFormatsByLocale = map[Locale]string{
 	LocaleUkUA: DefaultFormatUkUAMedium,
 	LocaleLtLT: DefaultFormatLtLTMedium,
 	LocaleThTH: DefaultFormatThTHMedium,
+	LocaleUzUZ: DefaultFormatUzUZMedium,
 }
 
 // ShortFormatsByLocale maps locales to the 'short' date formats for all
@@ -430,7 +440,7 @@ var ShortFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZShort,
 	LocaleUkUA: DefaultFormatUkUAShort,
 	LocaleLtLT: DefaultFormatLtLTShort,
-	LocaleThTH: DefaultFormatThTHShort,
+	LocaleUzUZ: DefaultFormatUzUZShort,
 }
 
 // DateTimeFormatsByLocale maps locales to the 'DateTime' date formats for
@@ -472,7 +482,7 @@ var DateTimeFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZDateTime,
 	LocaleUkUA: DefaultFormatUkUADateTime,
 	LocaleLtLT: DefaultFormatLtLTDateTime,
-	LocaleThTH: DefaultFormatThTHDateTime,
+	LocaleUzUZ: DefaultFormatUzUZDateTime,
 }
 
 // TimeFormatsByLocale maps locales to the 'Time' date formats for
@@ -514,5 +524,5 @@ var TimeFormatsByLocale = map[Locale]string{
 	LocaleCsCZ: DefaultFormatCsCZTime,
 	LocaleUkUA: DefaultFormatUkUATime,
 	LocaleLtLT: DefaultFormatLtLTTime,
-	LocaleThTH: DefaultFormatThTHTime,
+	LocaleUzUZ: DefaultFormatUzUZTime,
 }

--- a/format_kk_kz.go
+++ b/format_kk_kz.go
@@ -1,0 +1,85 @@
+package monday
+
+// ============================================================
+// Format rules for "kk_KZ" locale: Kazakh (Kazakhstan)
+// ============================================================
+
+var longDayNamesKkKZ = map[string]string{
+	"Sunday":    "Жексенбі",
+	"Monday":    "Дүйсенбі",
+	"Tuesday":   "Сейсенбі",
+	"Wednesday": "Сәрсенбі",
+	"Thursday":  "Бейсенбі",
+	"Friday":    "Жұма",
+	"Saturday":  "Сенбі",
+}
+
+var shortDayNamesKkKZ = map[string]string{
+	"Sun": "Жс",
+	"Mon": "Дс",
+	"Tue": "Сс",
+	"Wed": "Ср",
+	"Thu": "Бс",
+	"Fri": "Жм",
+	"Sat": "Сб",
+}
+
+var longMonthNamesKkKZ = map[string]string{
+	"January":   "Қаңтар",
+	"February":  "Ақпан",
+	"March":     "Наурыз",
+	"April":     "Сәуір",
+	"May":       "Мамыр",
+	"June":      "Маусым",
+	"July":      "Шілде",
+	"August":    "Тамыз",
+	"September": "Қыркүйек",
+	"October":   "Қазан",
+	"November":  "Қараша",
+	"December":  "Желтоқсан",
+}
+
+var longMonthNamesGenitiveKkKZ = map[string]string{
+	"January":   "қаңтар",
+	"February":  "ақпан",
+	"March":     "наурыз",
+	"April":     "сәуір",
+	"May":       "мамыр",
+	"June":      "маусым",
+	"July":      "шілде",
+	"August":    "тамыз",
+	"September": "қыркүйек",
+	"October":   "қазан",
+	"November":  "қараша",
+	"December":  "желтоқсан",
+}
+
+var shortMonthNamesKkKZ = map[string]string{
+	"Jan": "Қаң",
+	"Feb": "Ақп",
+	"Mar": "Нау",
+	"Apr": "Сәу",
+	"May": "Мам",
+	"Jun": "Мау",
+	"Jul": "Шіл",
+	"Aug": "Там",
+	"Sep": "Қыр",
+	"Oct": "Қаз",
+	"Nov": "Қар",
+	"Dec": "Жел",
+}
+
+var shortMonthNamesGenitiveKkKZ = map[string]string{
+	"Jan": "қаң",
+	"Feb": "ақп",
+	"Mar": "нау",
+	"Apr": "сәу",
+	"May": "мам",
+	"Jun": "мау",
+	"Jul": "шіл",
+	"Aug": "там",
+	"Sep": "қыр",
+	"Oct": "қаз",
+	"Nov": "қар",
+	"Dec": "жел",
+}

--- a/format_th_th.go
+++ b/format_th_th.go
@@ -1,0 +1,84 @@
+package monday
+
+import "strings"
+
+// ============================================================
+// Format rules for "th_TH" locale: Thai (Thailand)
+// ============================================================
+
+var longDayNamesThTH = map[string]string{
+	"Sunday":    "วันอาทิตย์",
+	"Monday":    "วันจันทร์",
+	"Tuesday":   "วันอังคาร",
+	"Wednesday": "วันพุธ",
+	"Thursday":  "วันพฤหัสบดี",
+	"Friday":    "วันศุกร์",
+	"Saturday":  "วันเสาร์",
+}
+
+var shortDayNamesThTH = map[string]string{
+	"Sun": "อา.",
+	"Mon": "จ.",
+	"Tue": "อ.",
+	"Wed": "พ.",
+	"Thu": "พฤ.",
+	"Fri": "ศ.",
+	"Sat": "ส.",
+}
+
+var longMonthNamesThTH = map[string]string{
+	"January":   "มกราคม",
+	"February":  "กุมภาพันธ์",
+	"March":     "มีนาคม",
+	"April":     "เมษายน",
+	"May":       "พฤษภาคม",
+	"June":      "มิถุนายน",
+	"July":      "กรกฎาคม",
+	"August":    "สิงหาคม",
+	"September": "กันยายน",
+	"October":   "ตุลาคม",
+	"November":  "พฤศจิกายน",
+	"December":  "ธันวาคม",
+}
+
+var shortMonthNamesThTH = map[string]string{
+	"Jan": "ม.ค.",
+	"Feb": "ก.พ.",
+	"Mar": "มี.ค.",
+	"Apr": "เม.ย.",
+	"May": "พ.ค.",
+	"Jun": "มิ.ย.",
+	"Jul": "ก.ค.",
+	"Aug": "ส.ค.",
+	"Sep": "ก.ย.",
+	"Oct": "ต.ค.",
+	"Nov": "พ.ย.",
+	"Dec": "ธ.ค.",
+}
+
+func parseFuncThCommon(locale Locale) internalParseFunc {
+	return func(layout, value string) string {
+		// This special case is needed because th_TH... contains month and day names
+		// that consist of dots, and special character. Example: "February" = "กุมภาพันธ์", "Feb" = "ก.พ."
+		//
+		// This means that probably default time package layout IDs like 'January' or 'Jan'
+		// shouldn't be used in th_TH. But this is a time-compatible package, so someone
+		// might actually use those and we need to replace those before doing standard procedures.
+		for k, v := range knownMonthsShortReverse[locale] {
+			value = strings.Replace(value, k, v, -1)
+		}
+		for k, v := range knownDaysShortReverse[locale] {
+			value = strings.Replace(value, k, v, -1)
+		}
+		for k, v := range knownMonthsLongReverse[locale] {
+			value = strings.Replace(value, k, v, -1)
+		}
+		for k, v := range knownDaysLongReverse[locale] {
+			value = strings.Replace(value, k, v, -1)
+		}
+
+		return commonFormatFunc(value, layout,
+			knownDaysShortReverse[locale], knownDaysLongReverse[locale],
+			knownMonthsShortReverse[locale], knownMonthsLongReverse[locale], knownPeriods[locale])
+	}
+}

--- a/format_uz_uz.go
+++ b/format_uz_uz.go
@@ -1,0 +1,85 @@
+package monday
+
+// ============================================================
+// Format rules for "uz_UZ" locale: Uzbek (Uzbeksitan)
+// ============================================================
+
+var longDayNamesUzUZ = map[string]string{
+	"Sunday":    "Yakshanba",
+	"Monday":    "Dushanba",
+	"Tuesday":   "Seshanba",
+	"Wednesday": "Chorshanba",
+	"Thursday":  "Payshanba",
+	"Friday":    "Juma",
+	"Saturday":  "Shanba",
+}
+
+var shortDayNamesUzUZ = map[string]string{
+	"Sun": "Ya",
+	"Mon": "Du",
+	"Tue": "Se",
+	"Wed": "Ch",
+	"Thu": "Pa",
+	"Fri": "Ju",
+	"Sat": "Sh",
+}
+
+var longMonthNamesUzUZ = map[string]string{
+	"January":   "Yanvar",
+	"February":  "Fevral",
+	"March":     "Mart",
+	"April":     "Aprel",
+	"May":       "May",
+	"June":      "Iyun",
+	"July":      "Iyul",
+	"August":    "Avgust",
+	"September": "Sentyabr",
+	"October":   "Oktyabr",
+	"November":  "Noyabr",
+	"December":  "Dekabr",
+}
+
+var longMonthNamesGenitiveUzUZ = map[string]string{
+	"January":   "yanvar",
+	"February":  "fevral",
+	"March":     "mart",
+	"April":     "aprel",
+	"May":       "may",
+	"June":      "iyun",
+	"July":      "iyul",
+	"August":    "avgust",
+	"September": "sentyabr",
+	"October":   "oktyabr",
+	"November":  "noyabr",
+	"December":  "dekabr",
+}
+
+var shortMonthNamesUzUZ = map[string]string{
+	"Jan": "Yan",
+	"Feb": "Fev",
+	"Mar": "Mar",
+	"Apr": "Apr",
+	"May": "May",
+	"Jun": "Iyun",
+	"Jul": "Iyul",
+	"Aug": "Avg",
+	"Sep": "Sen",
+	"Oct": "Okt",
+	"Nov": "Noy",
+	"Dec": "Dek",
+}
+
+var shortMonthNamesGenitiveUzUZ = map[string]string{
+	"Jan": "yan",
+	"Feb": "fev",
+	"Mar": "mar",
+	"Apr": "apr",
+	"May": "may",
+	"Jun": "iyun",
+	"Jul": "iyul",
+	"Aug": "avg",
+	"Sep": "sen",
+	"Oct": "okt",
+	"Nov": "noy",
+	"Dec": "dek",
+}

--- a/locale.go
+++ b/locale.go
@@ -47,6 +47,7 @@ const (
 	LocaleSlSI = "sl_SI" // Slovenian (Slovenia)
 	LocaleLtLT = "lt_LT" // Lithuanian (Lithuania)
 	LocaleThTH = "th_TH" // Thai (Thailand)
+	LocaleUzUZ = "uz_UZ" // Uzbek (Uzbekistan)
 )
 
 // ListLocales returns all locales supported by the package.
@@ -91,5 +92,6 @@ func ListLocales() []Locale {
 		LocaleSlSI,
 		LocaleLtLT,
 		LocaleThTH,
+		LocaleUzUZ,
 	}
 }

--- a/locale.go
+++ b/locale.go
@@ -46,6 +46,7 @@ const (
 	LocaleCsCZ = "cs_CZ" // Czech (Czech Republic)
 	LocaleSlSI = "sl_SI" // Slovenian (Slovenia)
 	LocaleLtLT = "lt_LT" // Lithuanian (Lithuania)
+	LocaleThTH = "th_TH" // Thai (Thailand)
 )
 
 // ListLocales returns all locales supported by the package.
@@ -89,5 +90,6 @@ func ListLocales() []Locale {
 		LocaleCsCZ,
 		LocaleSlSI,
 		LocaleLtLT,
+		LocaleThTH,
 	}
 }

--- a/locale.go
+++ b/locale.go
@@ -48,6 +48,7 @@ const (
 	LocaleLtLT = "lt_LT" // Lithuanian (Lithuania)
 	LocaleThTH = "th_TH" // Thai (Thailand)
 	LocaleUzUZ = "uz_UZ" // Uzbek (Uzbekistan)
+	LocaleKkKZ = "kk_KZ" // Kazakh (Kazakhstan)
 )
 
 // ListLocales returns all locales supported by the package.
@@ -93,5 +94,6 @@ func ListLocales() []Locale {
 		LocaleLtLT,
 		LocaleThTH,
 		LocaleUzUZ,
+		LocaleKkKZ,
 	}
 }

--- a/monday.go
+++ b/monday.go
@@ -48,6 +48,7 @@ var internalFormatFuncs = map[Locale]internalFormatFunc{
 	LocaleCsCZ: createCommonFormatFunc(LocaleCsCZ),
 	LocaleSlSI: createCommonFormatFunc(LocaleSlSI),
 	LocaleLtLT: createCommonFormatFuncWithGenitive(LocaleLtLT),
+	LocaleThTH: createCommonFormatFunc(LocaleThTH),
 }
 
 // internalParseFunc is a preprocessor for default time.ParseInLocation func
@@ -93,6 +94,7 @@ var internalParseFuncs = map[Locale]internalParseFunc{
 	LocaleCsCZ: createCommonParseFunc(LocaleCsCZ),
 	LocaleSlSI: createCommonParseFunc(LocaleSlSI),
 	LocaleLtLT: createCommonParsetFuncWithGenitive(LocaleLtLT),
+	LocaleThTH: parseFuncThCommon(LocaleThTH),
 }
 
 var knownDaysShort = map[Locale]map[string]string{}           // Mapping for 'Format', days of week, short form
@@ -365,6 +367,12 @@ func fillKnownWords() {
 	fillKnownMonthsShort(shortMonthNamesLtLT, LocaleLtLT)
 	fillKnownMonthsGenitiveLong(longMonthNamesGenitiveLtLT, LocaleLtLT)
 	fillKnownMonthsGenitiveShort(shortMonthNamesGenitiveLtLT, LocaleLtLT)
+
+	// Th_TH: Thai (Thailand)
+	fillKnownDaysLong(longDayNamesThTH, LocaleThTH)
+	fillKnownDaysShort(shortDayNamesThTH, LocaleThTH)
+	fillKnownMonthsLong(longMonthNamesThTH, LocaleThTH)
+	fillKnownMonthsShort(shortMonthNamesThTH, LocaleThTH)
 }
 
 func fill(src map[string]string, dest map[Locale]map[string]string, locale Locale) {

--- a/monday.go
+++ b/monday.go
@@ -50,6 +50,7 @@ var internalFormatFuncs = map[Locale]internalFormatFunc{
 	LocaleLtLT: createCommonFormatFuncWithGenitive(LocaleLtLT),
 	LocaleThTH: createCommonFormatFunc(LocaleThTH),
 	LocaleUzUZ: createCommonFormatFuncWithGenitive(LocaleUzUZ),
+	LocaleKkKZ: createCommonFormatFuncWithGenitive(LocaleKkKZ),
 }
 
 // internalParseFunc is a preprocessor for default time.ParseInLocation func
@@ -97,6 +98,7 @@ var internalParseFuncs = map[Locale]internalParseFunc{
 	LocaleLtLT: createCommonParsetFuncWithGenitive(LocaleLtLT),
 	LocaleThTH: parseFuncThCommon(LocaleThTH),
 	LocaleUzUZ: createCommonParsetFuncWithGenitive(LocaleUzUZ),
+	LocaleKkKZ: createCommonParsetFuncWithGenitive(LocaleKkKZ),
 }
 
 var knownDaysShort = map[Locale]map[string]string{}           // Mapping for 'Format', days of week, short form
@@ -383,6 +385,14 @@ func fillKnownWords() {
 	fillKnownMonthsShort(shortMonthNamesUzUZ, LocaleUzUZ)
 	fillKnownMonthsGenitiveLong(longMonthNamesGenitiveUzUZ, LocaleUzUZ)
 	fillKnownMonthsGenitiveShort(shortMonthNamesGenitiveUzUZ, LocaleUzUZ)
+
+	// Kk_KZ: Kazakh (Kazakhstan)
+	fillKnownDaysLong(longDayNamesKkKZ, LocaleKkKZ)
+	fillKnownDaysShort(shortDayNamesKkKZ, LocaleKkKZ)
+	fillKnownMonthsLong(longMonthNamesKkKZ, LocaleKkKZ)
+	fillKnownMonthsShort(shortMonthNamesKkKZ, LocaleKkKZ)
+	fillKnownMonthsGenitiveLong(longMonthNamesGenitiveKkKZ, LocaleKkKZ)
+	fillKnownMonthsGenitiveShort(shortMonthNamesGenitiveKkKZ, LocaleKkKZ)
 }
 
 func fill(src map[string]string, dest map[Locale]map[string]string, locale Locale) {

--- a/monday.go
+++ b/monday.go
@@ -49,6 +49,7 @@ var internalFormatFuncs = map[Locale]internalFormatFunc{
 	LocaleSlSI: createCommonFormatFunc(LocaleSlSI),
 	LocaleLtLT: createCommonFormatFuncWithGenitive(LocaleLtLT),
 	LocaleThTH: createCommonFormatFunc(LocaleThTH),
+	LocaleUzUZ: createCommonFormatFuncWithGenitive(LocaleUzUZ),
 }
 
 // internalParseFunc is a preprocessor for default time.ParseInLocation func
@@ -95,6 +96,7 @@ var internalParseFuncs = map[Locale]internalParseFunc{
 	LocaleSlSI: createCommonParseFunc(LocaleSlSI),
 	LocaleLtLT: createCommonParsetFuncWithGenitive(LocaleLtLT),
 	LocaleThTH: parseFuncThCommon(LocaleThTH),
+	LocaleUzUZ: createCommonParsetFuncWithGenitive(LocaleUzUZ),
 }
 
 var knownDaysShort = map[Locale]map[string]string{}           // Mapping for 'Format', days of week, short form
@@ -373,6 +375,14 @@ func fillKnownWords() {
 	fillKnownDaysShort(shortDayNamesThTH, LocaleThTH)
 	fillKnownMonthsLong(longMonthNamesThTH, LocaleThTH)
 	fillKnownMonthsShort(shortMonthNamesThTH, LocaleThTH)
+
+	// Uz_UZ: Uzbek (Uzbekistan)
+	fillKnownDaysLong(longDayNamesUzUZ, LocaleUzUZ)
+	fillKnownDaysShort(shortDayNamesUzUZ, LocaleUzUZ)
+	fillKnownMonthsLong(longMonthNamesUzUZ, LocaleUzUZ)
+	fillKnownMonthsShort(shortMonthNamesUzUZ, LocaleUzUZ)
+	fillKnownMonthsGenitiveLong(longMonthNamesGenitiveUzUZ, LocaleUzUZ)
+	fillKnownMonthsGenitiveShort(shortMonthNamesGenitiveUzUZ, LocaleUzUZ)
 }
 
 func fill(src map[string]string, dest map[Locale]map[string]string, locale Locale) {

--- a/monday_test.go
+++ b/monday_test.go
@@ -352,6 +352,14 @@ var formatTests = []FormatTest{
 	{LocaleSlSI, time.Date(2013, 5, 13, 0, 0, 0, 0, time.UTC), "2 Jan 2006", "13 maj 2013"},
 	{LocaleSlSI, time.Date(0, 5, 1, 0, 0, 0, 0, time.UTC), "January", "maj"},
 	{LocaleSlSI, time.Date(0, 5, 13, 0, 0, 0, 0, time.UTC), "2 January", "13 maj"},
+
+	{LocaleThTH, time.Date(2022, 7, 8, 0, 0, 0, 0, time.UTC), "Mon Jan 2 2006", "ศ. ก.ค. 8 2022"},
+	{LocaleThTH, time.Date(2022, 7, 8, 0, 0, 0, 0, time.UTC), "Monday Jan 2 2006", "วันศุกร์ ก.ค. 8 2022"},
+	{LocaleThTH, time.Date(2022, 2, 1, 0, 0, 0, 0, time.UTC), "Monday January 02 2006", "วันอังคาร กุมภาพันธ์ 01 2022"},
+	{LocaleThTH, time.Date(2022, 5, 13, 0, 0, 0, 0, time.UTC), "2006. 2 January.", "2022. 13 พฤษภาคม."},
+	{LocaleThTH, time.Date(2022, 5, 13, 0, 0, 0, 0, time.UTC), "2 Jan 2006", "13 พ.ค. 2022"},
+	{LocaleThTH, time.Date(0, 5, 1, 0, 0, 0, 0, time.UTC), "January", "พฤษภาคม"},
+	{LocaleThTH, time.Date(0, 5, 13, 0, 0, 0, 0, time.UTC), "2 January", "13 พฤษภาคม"},
 }
 
 func TestFormat(t *testing.T) {

--- a/monday_test.go
+++ b/monday_test.go
@@ -360,6 +360,15 @@ var formatTests = []FormatTest{
 	{LocaleThTH, time.Date(2022, 5, 13, 0, 0, 0, 0, time.UTC), "2 Jan 2006", "13 พ.ค. 2022"},
 	{LocaleThTH, time.Date(0, 5, 1, 0, 0, 0, 0, time.UTC), "January", "พฤษภาคม"},
 	{LocaleThTH, time.Date(0, 5, 13, 0, 0, 0, 0, time.UTC), "2 January", "13 พฤษภาคม"},
+
+	{LocaleUzUZ, time.Date(2013, 9, 3, 0, 0, 0, 0, time.UTC), "Mon Jan 2 2006", "Se Sen 3 2013"},
+	{LocaleUzUZ, time.Date(2013, 9, 4, 0, 0, 0, 0, time.UTC), "Monday Jan 2 2006", "Chorshanba Sen 4 2013"},
+	{LocaleUzUZ, time.Date(2013, 10, 3, 0, 0, 0, 0, time.UTC), "Monday January 02 2006", "Payshanba Oktyabr 03 2013"},
+	{LocaleUzUZ, time.Date(2013, 11, 3, 0, 0, 0, 0, time.UTC), "Monday. 2 January 2006", "Yakshanba. 3 noyabr 2013"},
+	{LocaleUzUZ, time.Date(2013, 5, 13, 0, 0, 0, 0, time.UTC), "2006. 2 January. Monday", "2013. 13 may. Dushanba"},
+	{LocaleUzUZ, time.Date(2013, 5, 13, 0, 0, 0, 0, time.UTC), "2 Jan 2006", "13 may 2013"},
+	{LocaleUzUZ, time.Date(0, 5, 1, 0, 0, 0, 0, time.UTC), "January", "May"},
+	{LocaleUzUZ, time.Date(0, 5, 13, 0, 0, 0, 0, time.UTC), "2 January", "13 may"},
 }
 
 func TestFormat(t *testing.T) {

--- a/monday_test.go
+++ b/monday_test.go
@@ -369,6 +369,15 @@ var formatTests = []FormatTest{
 	{LocaleUzUZ, time.Date(2013, 5, 13, 0, 0, 0, 0, time.UTC), "2 Jan 2006", "13 may 2013"},
 	{LocaleUzUZ, time.Date(0, 5, 1, 0, 0, 0, 0, time.UTC), "January", "May"},
 	{LocaleUzUZ, time.Date(0, 5, 13, 0, 0, 0, 0, time.UTC), "2 January", "13 may"},
+
+	{LocaleKkKZ, time.Date(2013, 9, 3, 0, 0, 0, 0, time.UTC), "Mon Jan 2 2006", "Сс Қыр 3 2013"},
+	{LocaleKkKZ, time.Date(2013, 9, 4, 0, 0, 0, 0, time.UTC), "Monday Jan 2 2006", "Сәрсенбі Қыр 4 2013"},
+	{LocaleKkKZ, time.Date(2013, 10, 3, 0, 0, 0, 0, time.UTC), "Monday January 02 2006", "Бейсенбі Қазан 03 2013"},
+	{LocaleKkKZ, time.Date(2013, 11, 3, 0, 0, 0, 0, time.UTC), "Monday. 2 January 2006", "Жексенбі. 3 қараша 2013"},
+	{LocaleKkKZ, time.Date(2013, 5, 13, 0, 0, 0, 0, time.UTC), "2006. 2 January. Monday", "2013. 13 мамыр. Дүйсенбі"},
+	{LocaleKkKZ, time.Date(2013, 5, 13, 0, 0, 0, 0, time.UTC), "2 Jan 2006", "13 мам 2013"},
+	{LocaleKkKZ, time.Date(0, 5, 1, 0, 0, 0, 0, time.UTC), "January", "Мамыр"},
+	{LocaleKkKZ, time.Date(0, 5, 13, 0, 0, 0, 0, time.UTC), "2 January", "13 мамыр"},
 }
 
 func TestFormat(t *testing.T) {


### PR DESCRIPTION
detectLocale method is inaccurate for word less than two characters so this method needs to be updated to fix issue when incorrectly detecting estonian language instead of english due "T" character.